### PR TITLE
feat: migrate all classes from `commons-web`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,18 @@ SOFTWARE.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.jcabi.incubator</groupId>
+      <artifactId>xembly</artifactId>
+      <version>0.23.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.surati.gap</groupId>
       <artifactId>admin-base</artifactId>
       <version>0.1</version>

--- a/src/main/java/io/surati/gap/web/base/rq/RootPageFull.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RootPageFull.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import org.takes.Request;
+import org.takes.rq.RqHref;
+
+import java.io.IOException;
+import java.util.Base64;
+
+final public class RootPageFull {
+
+	final String title;
+
+	final String subtitle;
+
+	final String uri;
+	
+	public RootPageFull(final Request req) throws IOException {
+		this(
+			new RqHref.Smart(req).single("root_page_title"),
+			new RqHref.Smart(req).single("root_page_subtitle"),
+			new String(
+				Base64.getUrlDecoder().decode(
+					new RqHref.Smart(req).single("root_page_uri")
+				)
+			)
+		);
+	}
+	
+	public RootPageFull(final String title, final String subtitle, final String uri) {
+		this.title = new UriDecode(title).toString();
+		this.subtitle = new UriDecode(subtitle).toString();
+		this.uri = uri;
+	}
+	
+	@Override
+	public String toString() {
+		return String.format(
+			"root_page_title=%s&root_page_subtitle=%s&root_page_uri=%s",
+			new UriEncode(this.title),
+			new UriEncode(this.subtitle),
+			Base64.getUrlEncoder().encodeToString(this.uri.getBytes())
+		);
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/rq/RootPageSubtitle.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RootPageSubtitle.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import org.takes.Request;
+import org.takes.rq.RqHref;
+
+import java.io.IOException;
+
+final public class RootPageSubtitle {
+
+	final String subtitle;
+	
+	public RootPageSubtitle(final Request req) throws IOException {
+		this(
+			new RqHref.Smart(req).single("root_page_subtitle")
+		);
+	}
+	
+	public RootPageSubtitle(final String subtitle) {
+		this.subtitle = subtitle;
+	}
+	
+	@Override
+	public String toString() {
+		return new UriDecode(this.subtitle).toString();
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/rq/RootPageTitle.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RootPageTitle.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import org.takes.Request;
+import org.takes.rq.RqHref;
+
+import java.io.IOException;
+
+final public class RootPageTitle {
+
+	final String title;
+	
+	public RootPageTitle(final Request req) throws IOException {
+		this(
+			new RqHref.Smart(req).single("root_page_title")
+		);
+	}
+	
+	public RootPageTitle(final String title) {
+		this.title = title;
+	}
+	
+	@Override
+	public String toString() {
+		return new UriDecode(this.title).toString();
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/rq/RootPageUri.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RootPageUri.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import org.takes.Request;
+import org.takes.rq.RqHref;
+
+import java.io.IOException;
+import java.util.Base64;
+
+final public class RootPageUri {
+
+	final String uri;
+	
+	public RootPageUri(final Request req) throws IOException {
+		this(
+		    new String(
+		    	Base64.getUrlDecoder().decode(
+		    		new RqHref.Smart(req).single("root_page_uri")
+				)
+	    	)
+		);
+	}
+
+	public RootPageUri(final String uri) {
+		this.uri = uri;
+	}
+	
+	@Override
+	public String toString() {
+		return this.uri;
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/rq/RqImageFilename.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RqImageFilename.java
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import org.takes.Request;
+import org.takes.rq.RqHeaders;
+
+import java.io.IOException;
+
+public final class RqImageFilename {
+
+    private final Request req;
+    
+    public RqImageFilename(final Request req) {
+        this.req = req;
+    }
+    
+    public String value() throws IOException {
+        final RqHeaders.Smart imgrq = new RqHeaders.Smart(req);
+        final String header = String.format("images/header/%s", imgrq.single("Content-Disposition"));
+        for (String content : header.split(";")) {
+            if (content.trim().startsWith("filename")) {
+                return content.substring(
+                        content.indexOf('=') + 1).trim().replace("\"", "");
+            }
+        }
+        throw new IllegalArgumentException("Request not contained filename property !");
+    }
+}

--- a/src/main/java/io/surati/gap/web/base/rq/RqJson.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RqJson.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import org.takes.Request;
+
+import javax.json.JsonStructure;
+import java.io.IOException;
+
+/**
+ * Request decorator that decodes JSON data from
+ * {@code application/json} format (RFC 1738).
+ *
+ * <p>It is highly recommended to use {@link org.takes.rq.RqGreedy}
+ * decorator before passing request to this class.
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author OURA Olivier Baudouin (baudolivier.oura@gmail.com)
+ * @see <a href="http://www.w3.org/TR/html401/interact/forms.html">
+ *     Forms in HTML</a>
+ * @see org.takes.rq.RqGreedy
+ * @since 0.9
+ */
+public interface RqJson extends Request {
+
+    /**
+     * Get request payload.
+     * @return JsonStructure
+     * @throws IOException if no json format
+     */
+	JsonStructure payload() throws IOException;
+}

--- a/src/main/java/io/surati/gap/web/base/rq/RqJsonBase.java
+++ b/src/main/java/io/surati/gap/web/base/rq/RqJsonBase.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import java.io.IOException;
+import javax.json.Json;
+import javax.json.JsonReader;
+import javax.json.JsonStructure;
+import org.takes.Request;
+import org.takes.rq.RqWrap;
+
+/**
+ * Base Json of a {@link Request}.
+ *
+ * @since 3.0
+ */
+public final class RqJsonBase extends RqWrap implements RqJson {
+	
+	/**
+     * Request.
+     */
+    private final Request req;
+    
+    /**
+     * Ctor.
+     * @param request Original request
+     */
+    public RqJsonBase(final Request request) {
+        super(request);
+        this.req = request;
+    }
+
+	@Override
+	public JsonStructure payload() throws IOException {			
+		JsonReader reader = null;		
+		try {
+			reader = Json.createReader(req.body());
+			return reader.read();
+		} finally {
+			if(reader != null)
+				reader.close();
+		}
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/rq/UriDecode.java
+++ b/src/main/java/io/surati/gap/web/base/rq/UriDecode.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+final public class UriDecode {
+
+	final String value;
+	
+	public UriDecode(final String value) {
+		this.value = value;
+	}
+	
+	@Override
+	public String toString() {
+		try {
+			return URLDecoder.decode(
+				this.value,
+				StandardCharsets.UTF_8.toString()
+			);
+		} catch (UnsupportedEncodingException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/rq/UriEncode.java
+++ b/src/main/java/io/surati/gap/web/base/rq/UriEncode.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Surati
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.web.base.rq;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+final public class UriEncode {
+
+	final String value;
+	
+	public UriEncode(final String value) {
+		this.value = value;
+	}
+	
+	@Override
+	public String toString() {
+		try {
+			return URLEncoder.encode(
+				this.value,
+				StandardCharsets.UTF_8.toString()
+			);
+		} catch (UnsupportedEncodingException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+}

--- a/src/main/java/io/surati/gap/web/base/xe/XeRootPage.java
+++ b/src/main/java/io/surati/gap/web/base/xe/XeRootPage.java
@@ -1,0 +1,89 @@
+/**
+MIT License
+
+Copyright (c) 2021 Surati
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package io.surati.gap.web.base.xe;
+
+import io.surati.gap.web.base.rq.RootPageFull;
+import io.surati.gap.web.base.rq.RootPageSubtitle;
+import io.surati.gap.web.base.rq.RootPageTitle;
+import io.surati.gap.web.base.rq.RootPageUri;
+import io.surati.gap.web.base.rq.UriDecode;
+import org.takes.Request;
+import org.takes.rq.RqRequestLine;
+import org.takes.rs.xe.XeDirectives;
+import org.takes.rs.xe.XeWrap;
+import org.xembly.Directives;
+
+import java.io.IOException;
+
+public final class XeRootPage extends XeWrap {
+	
+	public XeRootPage(final Request req) throws IOException {
+		this(
+			"root_page",
+			new RootPageTitle(req).toString(),
+			new RootPageSubtitle(req).toString(),
+			new RootPageUri(req).toString()
+		);
+	}
+	
+	public XeRootPage(
+		final String title, final String subtitle, final Request req
+	) throws IOException {
+		this(
+			"root_page",
+			title,
+			subtitle,
+			req
+		);
+	}
+
+	public XeRootPage(
+		final String name, final String title, final String subtitle, final Request req
+	) throws IOException {
+		this(
+			name,
+			new RootPageTitle(title).toString(),
+			new RootPageSubtitle(subtitle).toString(),
+			new RqRequestLine.Base(req).uri()
+	    );
+	}
+
+	public XeRootPage(
+		final String name, final String title, final String subtitle, final String uri
+	) {
+		super(
+			new XeDirectives(
+				new Directives()
+				.add(name)
+					.add("title").set(new UriDecode(title)).up()
+					.add("subtitle").set(new UriDecode(subtitle)).up()
+					.add("uri").set(uri).up()
+					.add("full").set(
+						new RootPageFull(title, subtitle, uri)
+					).up()
+				.up()
+			)
+		);
+	}
+}

--- a/src/test/java/io/surati/gap/web/base/rq/UriEncodeTest.java
+++ b/src/test/java/io/surati/gap/web/base/rq/UriEncodeTest.java
@@ -1,0 +1,16 @@
+package io.surati.gap.web.base.rq;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+final class UriEncodeTest {
+
+    @Test
+    void encodes() {
+        MatcherAssert.assertThat(
+            new UriEncode("https://gap.surati.io/login").toString(),
+            Matchers.equalTo("https%3A%2F%2Fgap.surati.io%2Flogin")
+        );
+    }
+}


### PR DESCRIPTION
We think that `commons-web` is unuseful because `web-base` plays the same role.

Fix: #12